### PR TITLE
manifests: Present initial manifest

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secondary
+---
+apiVersion: v1
+data:
+  USER_DOMAIN: secondary.io
+  DOMAIN_HOST_IP: 127.0.0.1
+  Corefile: |
+    .:53 {
+        auto {
+          directory /zones db\.(.*) {1}
+          reload 45s
+        }
+        reload
+        log
+    }
+kind: ConfigMap
+metadata:
+  name: secondary-dns
+  namespace: secondary
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secondary
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secondary
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secondary
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: secondary
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: secondary-dns
+  name: secondary-dns
+  namespace: secondary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: secondary-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: secondary-dns
+    spec:
+      containers:
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        imagePullPolicy: IfNotPresent
+        name: secondary-dns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        - name: secdns-zones
+          mountPath: /zones     
+          readOnly: true
+      - name: fedora
+        image: fedora:latest
+        command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        volumeMounts:
+        - name: secdns-zones
+          mountPath: /zones
+        env:
+          - name: USER_DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: secondary-dns
+                key: USER_DOMAIN
+          - name: DOMAIN_HOST_IP
+            valueFrom:
+              configMapKeyRef:
+                name: secondary-dns
+                key: DOMAIN_HOST_IP
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 1
+      volumes:
+      - name: config-volume
+        configMap:
+          defaultMode: 420
+          items:
+          - key: Corefile
+            path: Corefile
+          name: secondary-dns
+      - name: secdns-zones
+        emptyDir: {}


### PR DESCRIPTION
The auto plugin was checked manually by:
Manually creating a `/zones/db.dns` file via the fedora container.
Exposing the secondary-dns pod.
Running nslookup once the auto plugin refreshed the database.

The RBACs were not tested, but they are a skeleton that can be easily updated 
once we have the informer logic.

Used this as `db.dns`
```
$ORIGIN dns.
$TTL 1750
@       IN      SOA coredns1.dns. coredns0.dns. (
                                2017042748 ; serial
                                7200       ; refresh (2 hours)
                                3600       ; retry (1 hour)
                                1209600    ; expire (2 weeks)
                                3600       ; minimum (1 hour)
                                )

        IN NS coredns1.dns.

coredns0                IN  A           1.2.3.4
coredns1                IN  A           1.2.3.4
example                 IN  A           1.2.3.8
```
Signed-off-by: Or Shoval <oshoval@redhat.com>