### PR TITLE
makefile: Add basic cluster functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,255 +1,82 @@
-# VERSION defines the project version for the bundle.
-# Update this value when you upgrade the version of your project.
-# To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+REGISTRY ?= quay.io
+REPO ?= alonapaz
+IMAGE_TAG ?= latest
+IMG ?= $(REPO)/kubesecondarydns
+OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+TLS_SETTING := $(if $(filter $(OCI_BIN),podman),--tls-verify=false,)
 
-# CHANNELS define the bundle channels used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
-# To re-generate a bundle for other specific channels without changing the standard setup, you can:
-# - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
-# - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
+BIN_DIR = $(CURDIR)/build/_output/bin/
 
-# DEFAULT_CHANNEL defines the default channel used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
-# To re-generate a bundle for any other default channel without changing the default setup, you can:
-# - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
-# - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+export GOFLAGS=-mod=vendor
+export GO111MODULE=on
+export GOROOT=$(BIN_DIR)/go/
+export GOBIN=$(GOROOT)/bin/
+export PATH := $(GOBIN):$(PATH)
+export GO := $(GOBIN)/go
 
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
-# This variable is used to construct full image tags for bundle and catalog images.
-#
-# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# kubevirt.io/kubesecondarydns-bundle:$VERSION and kubevirt.io/kubesecondarydns-catalog:$VERSION.
-IMAGE_TAG_BASE ?= kubevirt.io/kubesecondarydns
+export KUBECTL ?= cluster/kubectl.sh
 
-# BUNDLE_IMG defines the image:tag used for the bundle.
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+$(GO):
+	hack/install-go.sh $(BIN_DIR) > /dev/null
 
-# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+# Run unit tests
+# TODO
+test: $(GO)
+	echo hello world
 
-# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
-# You can enable this value if you would like to use SHA Based Digests
-# To enable set flag to true
-USE_IMAGE_DIGESTS ?= false
-ifeq ($(USE_IMAGE_DIGESTS), true)
-	BUNDLE_GEN_FLAGS += --use-image-digests
-endif
+# Run e2e tests
+functest: $(GO)
+	GO=$(GO) ./hack/functest.sh
 
-# Image URL to use all building/pushing image targets
-IMG ?= controller:latest
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.0
+deploy:
+	$(KUBECTL) apply -f manifests/secondarydns.yaml
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+# Run go fmt against code
+fmt: $(GO)
+	$(GO) fmt ./...
 
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
+# Run go vet against code
+vet: $(GO)
+	$(GO) vet ./...
 
-.PHONY: all
-all: build
+build:
+	${OCI_BIN} build -t ${REGISTRY}/${IMG}:${IMAGE_TAG} .
 
-##@ General
+# Push the container image
+push:
+	$(OCI_BIN) push ${TLS_SETTING} ${REGISTRY}/${IMG}:${IMAGE_TAG}
 
-# The help target prints out all targets with their descriptions organized
-# beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk commands is responsible for reading the
-# entire set of makefiles included in this invocation, looking for lines of the
-# file as xyz: ## something, and then pretty-format the target and help. Then,
-# if there's a line with ##@ something, that gets pretty-printed as a category.
-# More info on the usage of ANSI control characters for terminal formatting:
-# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
-# More info on the awk command:
-# http://linuxcommand.org/lc3_adv_awk.php
+cluster-up:
+	./cluster/up.sh
 
-.PHONY: help
-help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+cluster-down:
+	./cluster/down.sh
 
-##@ Development
+cluster-sync:
+	./cluster/sync.sh
 
-.PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+cluster-clean:
+	./cluster/clean.sh
 
-.PHONY: generate
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+bump-kubevirtci:
+	./hack/bump-kubevirtci.sh
 
-.PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
+vendor: $(GO)
+	$(GO) mod tidy
+	$(GO) mod vendor
 
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
+.PHONY: \
+	test \
+	functest \
+	deploy \
+	fmt \
+	vet \
+	build \
+	push \
+	cluster-up \
+	cluster-down \
+	cluster-sync \
+	cluster-clean \
+	bump-kubevirtci \
+	vendor
 
-.PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
-
-##@ Build
-
-.PHONY: build
-build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
-
-.PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
-
-# If you wish built the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
-
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
-
-# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
-# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
-# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
-# To properly provided solutions that supports more than one platform you should use this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
-.PHONY: docker-buildx
-docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- docker buildx create --name project-v3-builder
-	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
-	- docker buildx rm project-v3-builder
-	rm Dockerfile.cross
-
-##@ Deployment
-
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
-
-.PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
-
-.PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-.PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
-
-.PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-##@ Build Dependencies
-
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-## Tool Binaries
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.10.0
-
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
-
-.PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-
-.PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
-	operator-sdk bundle validate ./bundle
-
-.PHONY: bundle-build
-bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-
-.PHONY: bundle-push
-bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
-
-.PHONY: opm
-OPM = ./bin/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
-
-# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-# These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
-# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
-# Push the catalog image.
-.PHONY: catalog-push
-catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+source ./cluster/cluster.sh
+cluster::install
+
+./cluster/kubectl.sh delete --ignore-not-found -f ./manifests/secondarydns.yaml || true
+
+# Wait until all objects are deleted
+until [[ `./cluster/kubectl.sh get ns | grep "secondary " | wc -l` -eq 0 ]]; do
+    sleep 5
+done

--- a/cluster/cli.sh
+++ b/cluster/cli.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source ./cluster/cluster.sh
+cluster::install
+
+$(cluster::path)/cluster-up/cli.sh "$@"

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -1,0 +1,54 @@
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.24'}
+export KUBEVIRT_NUM_NODES=2
+export KUBEVIRTCI_TAG='2211021552-8cca8c0'
+
+KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
+# The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
+CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}
+
+function cluster::_get_repo() {
+    git --git-dir ${CLUSTER_PATH}/.git remote get-url origin
+}
+
+function cluster::_get_tag() {
+    git -C ${CLUSTER_PATH} describe --tags
+}
+
+function cluster::install() {
+    # Remove cloned kubevirtci repository if it does not match the requested one
+    if [ -d ${CLUSTER_PATH} ]; then
+        if [ $(cluster::_get_repo) != ${KUBEVIRTCI_REPO} -o $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]; then
+          rm -rf ${CLUSTER_PATH}
+        fi
+    fi
+
+    if [ ! -d ${CLUSTER_PATH} ]; then
+        git clone https://github.com/kubevirt/kubevirtci.git ${CLUSTER_PATH}
+        (
+            cd ${CLUSTER_PATH}
+            git checkout ${KUBEVIRTCI_TAG}
+        )
+    fi
+}
+
+function cluster::path() {
+    echo -n ${CLUSTER_PATH}
+}
+
+function cluster::kubeconfig() {
+    echo -n ${CLUSTER_PATH}/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig
+}

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+source ./cluster/cluster.sh
+cluster::install
+
+$(cluster::path)/cluster-up/down.sh

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source ./cluster/cluster.sh
+cluster::install
+
+$(cluster::path)/cluster-up/kubectl.sh "$@"

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+source ./cluster/cluster.sh
+cluster::install
+
+registry_port=$(./cluster/cli.sh ports registry | tr -d '\r')
+export REGISTRY=localhost:$registry_port
+
+make build
+make push
+make cluster-clean
+make deploy
+
+pods_ready_wait() {
+  if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
+    echo "Waiting for non secondary-dns containers to be ready ..."
+    ./cluster/kubectl.sh wait pod --all -n kube-system --for=condition=Ready --timeout=5m
+  fi
+
+  wait_failed=''
+  max_retries=12
+  retry_counter=0
+  echo "Waiting for secondary dns deployment to be ready ..."
+  while [[ "$(./cluster/kubectl.sh wait deployment -n secondary secondary-dns --for=condition=Available --timeout=1m)" = $wait_failed ]] && [[ $retry_counter -lt $max_retries ]]; do
+    sleep 5s
+    retry_counter=$((retry_counter + 1))
+  done
+
+  if [ $retry_counter -eq $max_retries ]; then
+    echo "Failed/timed-out waiting for secondary-dns resources"
+    exit 1
+  else
+    echo "secondary-dns deployment is ready"
+  fi
+}
+
+pods_ready_wait

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex pipefail
+
+export DEPLOY_CNAO=${DEPLOY_CNAO:-false}
+export DEPLOY_KUBEVIRT=${DEPLOY_KUBEVIRT:-false}
+
+function getLatestPatchVersion {
+  local major_minors=$1
+  curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep .tag_name | grep ${major_minors} | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs
+}
+
+source ./cluster/cluster.sh
+CNAO_VERSION=v0.76.1
+
+#use kubevirt latest z stream release
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.56)
+cluster::install
+
+if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
+    $(cluster::path)/cluster-up/up.sh
+fi
+
+if [[ "${DEPLOY_CNAO}" = "true" ]]; then
+    # Deploy CNAO
+    ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSION}/namespace.yaml
+    ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSION}/network-addons-config.crd.yaml
+    ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSION}/operator.yaml
+    ./cluster/kubectl.sh create -f ./hack/cna/cna-cr.yaml
+
+    # wait for cluster operator
+    ./cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=800s
+fi
+
+if [[ "${DEPLOY_KUBEVIRT}" = "true" ]]; then
+    # deploy kubevirt
+    ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
+
+    # Ensure the KubeVirt CRD is created
+    count=0
+    until ./cluster/kubectl.sh get crd kubevirts.kubevirt.io; do
+        ((count++)) && ((count == 30)) && echo "KubeVirt CRD not found" && exit 1
+        echo "waiting for KubeVirt CRD"
+        sleep 1
+    done
+
+    ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+
+    # Ensure the KubeVirt CR is created
+    count=0
+    until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
+        ((count++)) && ((count == 30)) && echo "KubeVirt CR not found" && exit 1
+        echo "waiting for KubeVirt CR"
+        sleep 1
+    done
+
+    ./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 360s || (echo "KubeVirt not ready in time" && exit 1)
+fi
+
+echo "Done"

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+[[ ${#KUBEVIRTCI_TAG} != "18" ]] && echo "error getting KUBEVIRTCI_TAG" && exit 1
+
+sed -i "s/export KUBEVIRTCI_TAG=.*/export KUBEVIRTCI_TAG='${KUBEVIRTCI_TAG}'/g" cluster/cluster.sh
+
+git --no-pager diff cluster/cluster.sh | grep KUBEVIRTCI_TAG || true

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+echo hello world

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version=$(grep "^go " go.mod |awk '{print $2}')
+tarball=go$version.linux-amd64.tar.gz
+url=https://dl.google.com/go/
+
+mkdir -p $destination
+curl -L $url/$tarball -o $destination/$tarball
+tar -xvf $destination/$tarball -C $destination

--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -97,7 +97,7 @@ spec:
           mountPath: /zones     
           readOnly: true
       - name: status-monitor
-        image: quay.io/alonapaz/kubesecondarydns/controller:latest
+        image: registry:5000/alonapaz/kubesecondarydns:latest
         volumeMounts:
         - name: secdns-zones
           mountPath: /zones


### PR DESCRIPTION
Add cluster make targets
Align to the current docker file
allows to deploy the deployment via cluster-sync

The latest kubevirtci which supports DNS is included.

The `test` and `functest` targets are stubs that will be addressed on follow PRs.
