### PR TITLE
Remove the filting from the controller and pin the controller compilation to linux/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Build the manager binary
 FROM golang:1.19 as builder
-ARG TARGETOS
-ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,11 +14,7 @@ COPY main.go main.go
 COPY controllers/ controllers/
 
 # Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/main.go
+++ b/main.go
@@ -66,10 +66,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO zoneManager := manager.New()
 	if err = (&controllers.VirtualMachineInstanceReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("VirtualMachineInstance"),
 		Scheme: mgr.GetScheme(),
+		// TODO ZoneMananger: zoneManager
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachineInstance")
 		os.Exit(1)


### PR DESCRIPTION
The PR is updating the controller to listen to any VM create/update/delete event without any filtering,
the zoneManager will do the filtering anyway.

It also updates the controller comilation in the docker file to be pinned to linux/amd64.