### PR TITLE
github actions: Add lint

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,6 +17,13 @@
 name: checks
 on: [push, pull_request]
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run linter
+        run: make lint
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -29,12 +29,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-    - uses: arnested/go-version-action@v1
-      id: go-version
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ steps.go-version.outputs.minimal }}
     - name: Build cmd
       run: make build
   unit-test:
@@ -42,12 +36,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-    - uses: arnested/go-version-action@v1
-      id: go-version
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ steps.go-version.outputs.minimal }}
     - name: Run unit tests
       run: make test
   dco:

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ build:
 push:
 	$(OCI_BIN) push ${TLS_SETTING} ${REGISTRY}/${IMG}:${IMAGE_TAG}
 
+lint: $(GO)
+	GOFLAGS=-mod=mod $(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 --timeout 5m run
+
 cluster-up:
 	./cluster/up.sh
 
@@ -73,6 +76,7 @@ vendor: $(GO)
 	vet \
 	build \
 	push \
+	lint \
 	cluster-up \
 	cluster-down \
 	cluster-sync \


### PR DESCRIPTION
Add makefile target and github actions of go lint

Remove unneeded go version from github actions.
It is already defined in the makefile, and needed when running locally.
