### PR TITLE
controller: wait for kubevirt before starting

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -34,6 +34,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
If the controller will be starting before the virtualmachineinstances crd will be available the controller enter to a retry loop with a backoff and eventually crash.
Once virtualmachineinstances crd will be available, the backoff time may be very high which will cause a big delay in the controller startup.

To prevent this, the manager will wait for the crd to appear before starting the controller.

Signed-off-by: Alona Paz <alkaplan@redhat.com>