### PR TITLE
git actions: Remove dco

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -43,7 +43,3 @@ jobs:
         go-version: ${{ steps.go-version.outputs.minimal }}
     - name: Run unit tests
       run: make test
-  dco:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: tisonkun/actions-dco@v1.1


### PR DESCRIPTION
It seems it is broken
see https://github.com/tisonkun/actions-dco/issues/11 Once we have prow integration, prow plugins will check it.

Signed-off-by: Or Shoval <oshoval@redhat.com>