### PR TITLE
manifests: Add yaml separator

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
In order to allow CNAO to consume kube secondary dns 
the manifest should start with a separator,
because CNAO split the manifest according the separator 
in order to parameterize the needed fields.

Signed-off-by: Or Shoval <oshoval@redhat.com>