### PR TITLE
manifest: Add default container

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.24'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
 export KUBEVIRT_NUM_NODES=2
 export KUBEVIRTCI_TAG='2211212125-021efaa'
 

--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -71,6 +71,8 @@ spec:
     metadata:
       labels:
         k8s-app: secondary-dns
+      annotations:
+        kubectl.kubernetes.io/default-container: status-monitor
     spec:
       serviceAccountName: secondary
       containers:


### PR DESCRIPTION
This way we can run commands like `kubectl logs` without specifying
the container with `-c status-monitor`
as we usually need the status-monitor and not the secondary-dns container.

Had to bump to use k8s-1.25 so we can use
`kubectl.kubernetes.io/default-container` and not the deprecated one
`kubectl.kubernetes.io/default-logs-container`.

Note that it works only on 1.25 +