### PR TITLE
Dockerfile: Use ubi minimal base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,8 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
This will allow us to run shell in the container.
Packages can be installed using microdnf.

Signed-off-by: Or Shoval <oshoval@redhat.com>