### PR TITLE
Dockerfile: Add git ref labels

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -26,6 +26,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Version metadata
+        run: |
+          echo "git_commit_hash=$(git describe --no-match --always --abbrev=40 --dirty)" >> $GITHUB_ENV
+
       - name: set lower case repository name
         run: |
           echo "REPOSITORY_LC=${REPOSITORY,,}" >>${GITHUB_ENV}
@@ -40,6 +44,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:latest
           file: Dockerfile
+          build-args: |
+            git_sha=${{ env.git_commit_hash }}
 
       - name: Push tagged container image
         if: startsWith(github.ref, 'refs/tags/')
@@ -49,6 +55,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{  github.ref_name }}
           file: Dockerfile
+          build-args: |
+            git_sha=${{ env.git_commit_hash }}
 
       - name: Update release manifests
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "git_commit_hash=$(git describe --no-match --always --abbrev=40 --dirty)" >> $GITHUB_ENV
 
-      - name: set lower case repository name
+      - name: Set lower case repository name
         run: |
           echo "REPOSITORY_LC=${REPOSITORY,,}" >>${GITHUB_ENV}
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,10 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
+ARG git_url=https://github.com/AlonaKaplan/kubesecondarydns
+ARG git_sha=NONE
+
+LABEL multi.GIT_URL=${git_url} \
+      multi.GIT_SHA=${git_sha}
+
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ IMAGE_TAG ?= latest
 IMG ?= $(REPO)/kubesecondarydns
 OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
 TLS_SETTING := $(if $(filter $(OCI_BIN),podman),--tls-verify=false,)
+SHA := $(shell git describe --no-match --always --abbrev=40 --dirty)
 
 BIN_DIR = $(CURDIR)/build/_output/bin/
 
@@ -40,7 +41,7 @@ vet: $(GO)
 	$(GO) vet ./...
 
 build:
-	${OCI_BIN} build -t ${REGISTRY}/${IMG}:${IMAGE_TAG} .
+	${OCI_BIN} build -t ${REGISTRY}/${IMG}:${IMAGE_TAG} --build-arg git_sha=$(SHA) .
 
 # Push the container image
 push:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # KubeSecondaryDNS
 DNS for KubeVirt VirtualMachines secondary interfaces
+
+### Mapping a container image to the code
+In order to know which git commit hash was used to build a certain container image perform the following steps:
+```bash
+podman inspect --format '{{ index .Config.Labels "multi.GIT_SHA"}}' <IMAGE>
+```
+Note that it can also be inspected by skopeo without downloading the image.


### PR DESCRIPTION
In order to be able to resolve for each image what is the git
commit it was built from using docker inspect.

Can be inspected by using
`docker inspect --format '{{ index .Config.Labels "multi.GIT_URL"}}'`
`docker inspect --format '{{ index .Config.Labels "multi.GIT_SHA"}}'`

Beside that:
2nd commit is a cosmetic to capitalize the first word in a sentence.
