### PR TITLE
git actions: Fix image push owner

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -26,13 +26,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: set lower case repository name
+        run: |
+          echo "REPOSITORY_LC=${REPOSITORY,,}" >>${GITHUB_ENV}
+        env:
+          REPOSITORY: '${{ github.repository }}'
+
       - name: Push latest container image
         if: github.repository_owner == 'AlonaKaplan'
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ghcr.io/${{ env.REPOSITORY_LC }}:latest
           file: Dockerfile
 
       - name: Push tagged container image
@@ -41,12 +47,12 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{  github.ref_name }}
+          tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{  github.ref_name }}
           file: Dockerfile
 
       - name: Update release manifests
         if: startsWith(github.ref, 'refs/tags/')
-        run: IMAGE=ghcr.io/${{ github.repository }}:${{  github.ref_name }} hack/update-manifest.sh
+        run: IMAGE=ghcr.io/${{ env.REPOSITORY_LC }}:${{  github.ref_name }} hack/update-manifest.sh
 
       - name: Release the kraken
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Image repository should be lower case.

https://github.com/AlonaKaplan/kubesecondarydns/actions/runs/3507917825/jobs/5875956544

```
ERROR: invalid tag "ghcr.io/AlonaKaplan/kubesecondarydns:latest": repository name must be lowercase
Error: buildx failed with: ERROR: invalid tag "ghcr.io/AlonaKaplan/kubesecondarydns:latest": repository name must be lowercase
```

Signed-off-by: Or Shoval <oshoval@redhat.com>