### PR TITLE
podman: Fix building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM docker.io/library/golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Since podman doesn't support short image url,
use explicit url for go image.

Note: didn't check deploying, only building so far (locally).
The prow e2e is using podman so we will know if there are problems on CI.
Once we have e2e tests I will check end 2 end with podman locally.
