### PR TITLE
make: Add create node port target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ cluster-sync:
 cluster-clean:
 	./cluster/clean.sh
 
+create-nodeport:
+	./hack/create-nodeport.sh
+
 bump-kubevirtci:
 	./hack/bump-kubevirtci.sh
 
@@ -80,6 +83,7 @@ vendor: $(GO)
 	cluster-down \
 	cluster-sync \
 	cluster-clean \
+	create-nodeport \
 	bump-kubevirtci \
 	vendor
 

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -51,3 +51,4 @@ pods_ready_wait() {
 }
 
 pods_ready_wait
+make create-nodeport

--- a/hack/create-nodeport.sh
+++ b/hack/create-nodeport.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+if [ -z $KUBECONFIG ]; then
+  KUBECTL=./cluster/kubectl.sh
+else
+  KUBECTL=kubectl
+fi
+
+NAMESPACE=$($KUBECTL get pod -lk8s-app=secondary-dns -A -o=custom-columns=NS:.metadata.namespace --no-headers)
+
+if [ -z $NAMESPACE ]; then
+  echo "ERROR: namespace not found"
+  exit 1
+fi
+
+${KUBECTL} expose -n ${NAMESPACE} deployment/secondary-dns --name=dns-nodeport --type=NodePort --port=31111 --target-port=53 --protocol='UDP'
+${KUBECTL} patch -n ${NAMESPACE} service/dns-nodeport --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":31111}]'


### PR DESCRIPTION
Present a new make target that allows to create the required node port
(listens to port `31111` as exposed by kubevirtci).
It auto detects the namespace
and can be used either standalone or when deployed by CNAO.

Note: we support only namespaced deployment.
