### PR TITLE
Bump kubevirtci

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -14,7 +14,7 @@
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.24'}
 export KUBEVIRT_NUM_NODES=2
-export KUBEVIRTCI_TAG='2211021552-8cca8c0'
+export KUBEVIRTCI_TAG='2211212125-021efaa'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
In order to consume the latest changes of DNS
https://github.com/kubevirt/kubevirtci/pull/903
Note that the default host port is `31111` and not `53` so use it with nslookup.

Signed-off-by: Or Shoval <oshoval@redhat.com>