### PR TITLE
images: Align registry and repo to be consistent with github actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REGISTRY ?= quay.io
-REPO ?= alonapaz
+REGISTRY ?= ghcr.io
+REPO ?= alonakaplan
 IMAGE_TAG ?= latest
 IMG ?= $(REPO)/kubesecondarydns
 OCI_BIN ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)

--- a/hack/update-manifest.sh
+++ b/hack/update-manifest.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-sed -i 's@registry:5000/alonapaz/kubesecondarydns:latest@'"$IMAGE"'@' manifests/secondarydns.yaml
+sed -i 's@registry:5000/alonakaplan/kubesecondarydns:latest@'"$IMAGE"'@' manifests/secondarydns.yaml

--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -100,7 +100,7 @@ spec:
           mountPath: /zones     
           readOnly: true
       - name: status-monitor
-        image: registry:5000/alonapaz/kubesecondarydns:latest
+        image: registry:5000/alonakaplan/kubesecondarydns:latest
         volumeMounts:
         - name: secdns-zones
           mountPath: /zones


### PR DESCRIPTION
Since we push to `ghcr.io/alonakaplan` with github actions,
align all instances in the code to use those registry / repository.

Once we move under kubevirt we will align accordingly.

Signed-off-by: Or Shoval <oshoval@redhat.com>